### PR TITLE
Hide the Sublime's folder default sidebar icons.

### DIFF
--- a/Brogrammer.sublime-theme
+++ b/Brogrammer.sublime-theme
@@ -621,7 +621,18 @@
 //
 // SIDEBAR - GENERAL FILE ICONS
 //
-
+    {
+        "class": "icon_file_type",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder",
+        "content_margin": [0,0]
+    },
+    {
+        "class": "icon_folder_loading",
+        "content_margin": [0,0]
+    },
     // Sidebar group closed
     {
         "class": "disclosure_button_control",


### PR DESCRIPTION
This is my first Github pull request so tell me if something is wrong about it.
