### PR TITLE
Made the scroll puck visible

### DIFF
--- a/Brogrammer.sublime-theme
+++ b/Brogrammer.sublime-theme
@@ -276,7 +276,7 @@
         "class": "scroll_bar_control",
         "attributes": ["horizontal"],
         "layer0.texture": "",
-        "layer0.tint":[34,34,341],
+        "layer0.tint":[34,34,34],
         "layer0.inner_margin": [0,0],
         "blur": true
     },

--- a/Brogrammer.sublime-theme
+++ b/Brogrammer.sublime-theme
@@ -266,7 +266,7 @@
     {
         "class": "scroll_bar_control",
         "layer0.texture": "",
-        "layer0.tint":[51,51,51],
+        "layer0.tint":[34,34,34],
         "layer0.opacity": 1,
         "layer0.inner_margin": [0,0],
         "blur": true
@@ -276,7 +276,7 @@
         "class": "scroll_bar_control",
         "attributes": ["horizontal"],
         "layer0.texture": "",
-        "layer0.tint":[51,51,51],
+        "layer0.tint":[34,34,341],
         "layer0.inner_margin": [0,0],
         "blur": true
     },


### PR DESCRIPTION
Previously it was impossible to see where the scroll puck currently is on a scroll bar. Corected by making scroll bar background darker than the scroll puck is.