### PR TITLE
Lighter Gutter Foreground Color

### DIFF
--- a/brogrammer.tmTheme
+++ b/brogrammer.tmTheme
@@ -300,7 +300,7 @@
                 <key>name</key>
                 <string>css tag-name</string>
                 <key>scope</key>
-                <string>meta.selector.css entity.name.tag</string>
+                <string>meta.selector.css entity.name.tag, entity.name.tag.css.sass.symbol</string>
                 <key>settings</key>
                 <dict>
                     <key>foreground</key>

--- a/brogrammer.tmTheme
+++ b/brogrammer.tmTheme
@@ -32,7 +32,7 @@
                     <key>gutter</key>
                     <string>#222222</string>
                     <key>gutterForeground</key>
-                    <string>#ffffff</string>
+                    <string>#555555</string>
                     <key>guide</key>
                     <string>#222222</string>
                     <key>activeGuide</key>


### PR DESCRIPTION
Gutter foreground color (line numbers) was completely white which is
iritant and sometimes can distract from coding.

If you agree you can accept this pull request

![image](https://cloud.githubusercontent.com/assets/3611264/13396883/4d627126-def7-11e5-8a40-7c431bd09494.png)

I also added tag coloration for sass as it is in css.
