### PR TITLE
Recover orange color for function arguments

### DIFF
--- a/brogrammer.tmTheme
+++ b/brogrammer.tmTheme
@@ -180,6 +180,19 @@
             </dict>
             <dict>
                 <key>name</key>
+                <string>Function argument</string>
+                <key>scope</key>
+                <string>variable.parameter</string>
+                <key>settings</key>
+                <dict>
+                    <key>foreground</key>
+                    <string>#e67e22</string>
+                    <key>fontStyle</key>
+                    <string/>
+                </dict>
+            </dict>
+            <dict>
+                <key>name</key>
                 <string>Entity inherited-class</string>
                 <key>scope</key>
                 <string>entity.other.inherited-class</string>


### PR DESCRIPTION
Latest commit changed also function argument variables from orange to white. This pull request recovers this color only for function arguments.

Preview (Javascript):
![js-fixed](https://cloud.githubusercontent.com/assets/7250722/13955816/66ebcf56-f046-11e5-8b03-86cc50ff2430.png)

Preview (Python):
![py-fixed](https://cloud.githubusercontent.com/assets/7250722/13955833/78ffe696-f046-11e5-9d7b-f913423cf4d6.png)

