### PR TITLE
Use orange color for special class keywords (self, this, etc.)

### DIFF
--- a/brogrammer.tmTheme
+++ b/brogrammer.tmTheme
@@ -277,6 +277,19 @@
                 </dict>
             </dict>
             <dict>
+            <key>name</key>
+                <string>Library class/type</string>
+                <key>scope</key>
+                <string>support.type, support.class, variable.language</string>
+                <key>settings</key>
+                <dict>
+                    <key>fontStyle</key>
+                    <string/>
+                    <key>foreground</key>
+                    <string>#e67e22</string>
+                </dict>
+            </dict>
+            <dict>
                 <key>name</key>
                 <string>C/C++ Preprocessor Line</string>
                 <key>scope</key>


### PR DESCRIPTION
Use orange color also for special class keywords (i.e. self in python or this in javascript).