### PR TITLE
Remove italic from comment definition, causes l to appear as L

### DIFF
--- a/brogrammer.tmTheme
+++ b/brogrammer.tmTheme
@@ -68,8 +68,6 @@
                 <string>comment</string>
                 <key>settings</key>
                 <dict>
-                    <key>fontStyle</key>
-                    <string>italic</string>
                     <key>foreground</key>
                     <string>#606060</string>
                 </dict>


### PR DESCRIPTION
The italics on comments is causing some issues with the l letter.
See: https://github.com/kenwheeler/brogrammer-theme/issues/27
